### PR TITLE
Feat: Automatic release after build :godmode:

### DIFF
--- a/.github/workflows/maven-automatic.yml
+++ b/.github/workflows/maven-automatic.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [master]
   pull_request:
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/maven-automatic.yml
+++ b/.github/workflows/maven-automatic.yml
@@ -41,9 +41,6 @@ jobs:
     runs-on: ubuntu-latest
     name: "Deploy Job"
     needs: build
-    permissions:
-      contents: read
-      packages: write
       
     steps:
     - name: Download package
@@ -56,10 +53,8 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         automatic_release_tag: 'latest'
-        prerelease: false
+        prerelease: ${{ GITHUB_EVENT_NAME == 'pull_request' }}
         draft: false
         title: "Latest Release Build"
         files: |
           Package
-          LICENSE.txt
-          README.md

--- a/.github/workflows/maven-automatic.yml
+++ b/.github/workflows/maven-automatic.yml
@@ -57,4 +57,4 @@ jobs:
         draft: false
         title: "Latest Release Build"
         files: |
-          Package
+          *.hpi

--- a/.github/workflows/maven-automatic.yml
+++ b/.github/workflows/maven-automatic.yml
@@ -1,0 +1,65 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Maven Automatic Package
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    name: "Build Job"
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Build with Maven
+      run: mvn -Drevision=1145.vb_cf6cf6ed960 -B package --file pom.xml
+    
+    - run: mkdir staging && cp target/*.hpi staging
+    - uses: actions/upload-artifact@v3
+      with:
+        name: Package
+        path: staging/*
+        if-no-files-found: error
+        
+  deploy:
+    runs-on: ubuntu-latest
+    name: "Deploy Job"
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+      
+    steps:
+    - name: Download package
+      uses: actions/download-artifact@v3
+      with:
+        name: Package
+    
+    - name: Create release
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        automatic_release_tag: 'latest'
+        prerelease: false
+        draft: false
+        title: "Latest Release Build"
+        files: |
+          Package
+          LICENSE.txt
+          README.md

--- a/.github/workflows/maven-automatic.yml
+++ b/.github/workflows/maven-automatic.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         automatic_release_tag: 'latest'
-        prerelease: ${{ GITHUB_EVENT_NAME == 'pull_request' }}
+        prerelease: ${{ env.GITHUB_EVENT_NAME == 'pull_request' }}
         draft: false
         title: "Latest Release Build"
         files: |

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -60,11 +60,13 @@ jobs:
     name: "Deploy Job"
     needs: build
     if: ${{ github.event.inputs.createRelease == true }}
-    permissions:
-      contents: read
-      packages: write
       
     steps:
+    - name: debug input variables
+      run: |
+        echo pre-release: ${{ github.event.inputs.buildTag != 'latest' }}
+        echo draft: ${{ github.event.inputs.buildTag != 'latest' }}
+    
     - name: Download package
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -78,8 +78,8 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         automatic_release_tag: ${{ github.event.inputs.buildTag }}
-        prerelease: ${{ github.event.inputs.buildTag != "latest" }}
-        draft: ${{ github.event.inputs.buildTag != "latest" }}
+        prerelease: ${{ github.event.inputs.buildTag != 'latest' }}
+        draft: ${{ github.event.inputs.buildTag != 'latest' }}
         title: "${{ github.event.inputs.buildTag }} Release Build"
         files: |
           Package

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,6 +36,8 @@ jobs:
       packages: write
 
     steps:
+    - run: echo ${{ github.event.inputs.createRelease == true }}
+    - run: echo ${{ github.event.inputs.createRelease == 'true' }}
     - uses: actions/checkout@v2
     - name: Set up JDK 11
       uses: actions/setup-java@v2

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -84,6 +84,4 @@ jobs:
         draft: ${{ github.event.inputs.buildTag != 'latest' }}
         title: "${{ github.event.inputs.buildTag }} Release Build"
         files: |
-          Package
-          LICENSE.txt
-          README.md
+          *.hpi

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -19,7 +19,7 @@ on:
       buildTag:
         description: "Build tag to use for action (change if needed)"
         required: false
-        default: "latest"
+        default: latest
         type: choice
         options:
         - latest
@@ -64,8 +64,8 @@ jobs:
     steps:
     - name: debug input variables
       run: |
-        echo pre-release: ${{ github.event.inputs.buildTag != latest }}
-        echo draft: ${{ github.event.inputs.buildTag != latest }}
+        echo pre-release: ${{ github.event.inputs.buildTag != 'latest' }}
+        echo draft: ${{ github.event.inputs.buildTag != 'latest' }}
     
     - name: Download package
       uses: actions/download-artifact@v3

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -69,12 +69,12 @@ jobs:
       
     steps:
     - name: Download package
-    - uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v3
       with:
         name: Package
     
     - name: Create release
-    - uses: "marvinpinto/action-automatic-releases@latest"
+      uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         automatic_release_tag: ${{ github.event.inputs.buildTag }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -12,7 +12,7 @@ on:
         default: "1145.vb_cf6cf6ed960"
         type: string
       createRelease:
-        description: "Weather or not the build should trigger a new release on Github"
+        description: "Wether or not the build should trigger a new release on Github"
         required: false
         default: true
         type: boolean
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Deploy Job"
     needs: build
-    if: github.event.inputs.createRelease == 'true'
+    if: ${{ github.event.inputs.createRelease == 'true' }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -25,9 +25,6 @@ on:
         - latest
         - pre-release
         - dev-build
-  push:
-    branches: [master]
-  pull_request:
 
 jobs:
   build:
@@ -39,10 +36,6 @@ jobs:
       packages: write
 
     steps:
-    - run: echo ${{ github.event.inputs.createRelease == 'true' }}
-    - run: echo ${{ github.event.inputs.createRelease == true }}
-    - run: echo ${{ github.event.inputs.createRelease == 'false' }}
-    - run: echo ${{ github.event.inputs.createRelease == false }}
     - uses: actions/checkout@v2
     - name: Set up JDK 11
       uses: actions/setup-java@v2

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -64,13 +64,16 @@ jobs:
     steps:
     - name: debug input variables
       run: |
-        echo pre-release: ${{ github.event.inputs.buildTag != 'latest' }}
-        echo draft: ${{ github.event.inputs.buildTag != 'latest' }}
+        echo pre-release: ${{ github.event.inputs.buildTag != latest }}
+        echo draft: ${{ github.event.inputs.buildTag != latest }}
     
     - name: Download package
       uses: actions/download-artifact@v3
       with:
         name: Package
+    
+    - name: Check files
+      run: ls -al
     
     - name: Create release
       uses: "marvinpinto/action-automatic-releases@latest"

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Deploy Job"
     needs: build
-    if: github.event.inputs.createRelease
+    if: github.event.inputs.createRelease == 'true'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Deploy Job"
     needs: build
-    if: ${{ github.event.inputs.createRelease == 'true' }}
+    if: ${{ github.event.inputs.createRelease == true }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -39,6 +39,8 @@ jobs:
       packages: write
 
     steps:
+    - run: echo '${{ github.event.inputs.createRelease }}'
+    - run: echo ${{ github.event.inputs.createRelease == 'true' }}
     - uses: actions/checkout@v2
     - name: Set up JDK 11
       uses: actions/setup-java@v2

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -11,6 +11,20 @@ on:
         required: false
         default: "1145.vb_cf6cf6ed960"
         type: string
+      createRelease:
+        description: "Weather or not the build should trigger a new release on Github"
+        required: false
+        default: true
+        type: boolean
+      buildTag:
+        description: "Build tag to use for action (change if needed)"
+        required: false
+        default: "latest"
+        type: choice
+        options:
+        - latest
+        - pre-release
+        - dev-build
   push:
     branches: [master]
   pull_request:
@@ -19,6 +33,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    name: "Build Job"
     permissions:
       contents: read
       packages: write
@@ -35,10 +50,38 @@ jobs:
 
     - name: Build with Maven
       run: mvn -Drevision=${{ github.event.inputs.manualVersion }} -B package --file pom.xml
-      
+    
     - run: mkdir staging && cp target/*.hpi staging
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: Package
         path: staging/*
         if-no-files-found: error
+        
+  deploy:
+    runs-on: ubuntu-latest
+    name: "Deploy Job"
+    needs: build
+    if: ${{ github.event.inputs.createRelease }}
+    permissions:
+      contents: read
+      packages: write
+      
+    steps:
+    - name: Download package
+    - uses: actions/download-artifact@v3
+      with:
+        name: Package
+    
+    - name: Create release
+    - uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        automatic_release_tag: ${{ github.event.inputs.buildTag }}
+        prerelease: ${{ github.event.inputs.buildTag != "latest" }}
+        draft: ${{ github.event.inputs.buildTag != "latest" }}
+        title: "${{ github.event.inputs.buildTag }} Release Build"
+        files: |
+          Package
+          LICENSE.txt
+          README.md

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -82,6 +82,6 @@ jobs:
         automatic_release_tag: ${{ github.event.inputs.buildTag }}
         prerelease: ${{ github.event.inputs.buildTag != 'latest' }}
         draft: ${{ github.event.inputs.buildTag != 'latest' }}
-        title: "${{ github.event.inputs.buildTag }} Release Build"
+        title: "${{ github.event.inputs.buildTag }}  Release Build"
         files: |
           *.hpi

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Deploy Job"
     needs: build
-    if: ${{ github.event.inputs.createRelease }}
+    if: github.event.inputs.createRelease
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -39,8 +39,10 @@ jobs:
       packages: write
 
     steps:
-    - run: echo '${{ github.event.inputs.createRelease }}'
     - run: echo ${{ github.event.inputs.createRelease == 'true' }}
+    - run: echo ${{ github.event.inputs.createRelease == true }}
+    - run: echo ${{ github.event.inputs.createRelease == 'false' }}
+    - run: echo ${{ github.event.inputs.createRelease == false }}
     - uses: actions/checkout@v2
     - name: Set up JDK 11
       uses: actions/setup-java@v2

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,8 +36,6 @@ jobs:
       packages: write
 
     steps:
-    - run: echo ${{ github.event.inputs.createRelease == true }}
-    - run: echo ${{ github.event.inputs.createRelease == 'true' }}
     - uses: actions/checkout@v2
     - name: Set up JDK 11
       uses: actions/setup-java@v2
@@ -61,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Deploy Job"
     needs: build
-    if: ${{ github.event.inputs.createRelease == true }}
+    if: ${{ github.event.inputs.createRelease == 'true' }}
       
     steps:
     - name: debug input variables


### PR DESCRIPTION
# Description
We wanted to have automatic releases for the repo everytime a build is triggered. With these changes now a new release should be made automatically every time we push to master or we make a pull request. Additionally, you can also set it up with manual dispatches for this action.

# Changes:
1. Bumped the `actions/upload-artifact` action from `v2` to `v3` 👍.
2. Created a new deploy job 👀.
3. Added parameters to customize manual runs of the action 📝.
5. Added the `actions/download-artifact@v3` to use on the deploy job 🎉.
6. Added the `marvinpinto/action-automatic-releases` action to create the release for us 🥳.