### PR TITLE
fix: Added changelist variable :tada:

### DIFF
--- a/.github/workflows/maven-automatic.yml
+++ b/.github/workflows/maven-automatic.yml
@@ -29,7 +29,7 @@ jobs:
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
     - name: Build with Maven
-      run: mvn -Drevision=1145.vb_cf6cf6ed960 -B package --file pom.xml
+      run: mvn -Dchangelist=1145.vb_cf6cf6ed960 -Drevision=1145.vb_cf6cf6ed960 -B package --file pom.xml
     
     - run: mkdir staging && cp target/*.hpi staging
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/maven-automatic.yml
+++ b/.github/workflows/maven-automatic.yml
@@ -29,7 +29,7 @@ jobs:
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
     - name: Build with Maven
-      run: mvn -Dchangelist=1145.vb_cf6cf6ed960 -Drevision=1145.vb_cf6cf6ed960 -B package --file pom.xml
+      run: mvn -B package --file pom.xml
     
     - run: mkdir staging && cp target/*.hpi staging
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -46,7 +46,7 @@ jobs:
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
     - name: Build with Maven
-      run: mvn -Drevision=${{ github.event.inputs.manualVersion }} -B package --file pom.xml
+      run: mvn -Dchangelist=${{ github.event.inputs.manualVersion }} -Drevision=${{ github.event.inputs.manualVersion }} -B package --file pom.xml
     
     - run: mkdir staging && cp target/*.hpi staging
     - uses: actions/upload-artifact@v3

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <changelist>999999-SNAPSHOT</changelist>
+    <changelist>${revision}</changelist>
     <jenkins.version>2.324</jenkins.version>
     <java.level>8</java.level>
     <useBeta>true</useBeta>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <changelist>${revision}</changelist>
+    <changelist>999999-SNAPSHOT</changelist>
     <jenkins.version>2.324</jenkins.version>
     <java.level>8</java.level>
     <useBeta>true</useBeta>


### PR DESCRIPTION
# Description
The version number the `.hpi` file is displaying on Jenkins is `999999-SNAPSHOT`, this is because of how the `pom.xml` file is created but in theory this should override the version number.